### PR TITLE
DisplayName fallback for PLEX.

### DIFF
--- a/mopidy_dleyna/client.py
+++ b/mopidy_dleyna/client.py
@@ -71,6 +71,7 @@ class Servers(collections.Mapping):
     def __add_server(self, obj):
         udn = obj["UDN"]
         obj["URI"] = uritools.uricompose(Extension.ext_name, udn)
+        obj["DisplayName"] = obj.get("DisplayName", obj["URI"])
         key = udn.lower()
         if key not in self:
             self.__log_server_action("Found", obj)

--- a/mopidy_dleyna/translator.py
+++ b/mopidy_dleyna/translator.py
@@ -67,7 +67,7 @@ def ref(obj):
     except KeyError:
         raise ValueError('Object type "%s" not supported' % type)
     else:
-        return translate(name=obj["DisplayName"], uri=obj["URI"])
+        return translate(name=obj.get("DisplayName", obj["URI"]), uri=obj["URI"])
 
 
 def album(obj):


### PR DESCRIPTION
Hi Tomas
Plex doesn't deliver the field DisplayName. Therefore I implemented to take the URI instead.

Other clients like Infuse or VLC are able to deal with this issue. I think it would be cool if Mopidy can use Plex as well as a backend.

Best regards
Carsten

Issue came up here https://github.com/tkem/mopidy-dleyna/issues/59 or here https://forums.plex.tv/t/missing-field-displayname-in-dlna-response/582685  
