### PR TITLE
Fix "AttributeError: module 'collections' has no attribute 'Mapping'"

### DIFF
--- a/mopidy_dleyna/client.py
+++ b/mopidy_dleyna/client.py
@@ -6,6 +6,8 @@ import time
 import dbus
 import uritools
 
+from collections.abc import Mapping
+
 from . import Extension, util
 
 SERVER_BUS_NAME = "com.intel.dleyna-server"
@@ -41,7 +43,7 @@ def urimapper(baseuri, prefix="/com/intel/dLeynaServer/server/"):
     return mapper
 
 
-class Servers(collections.Mapping):
+class Servers(Mapping):
     def __init__(self, bus):
         self.__bus = bus
         self.__lock = threading.RLock()

--- a/mopidy_dleyna/client.py
+++ b/mopidy_dleyna/client.py
@@ -1,12 +1,10 @@
-import collections
+from collections.abc import Mapping
 import logging
 import threading
 import time
 
 import dbus
 import uritools
-
-from collections.abc import Mapping
 
 from . import Extension, util
 


### PR DESCRIPTION
Mapping is no longer accesible through `collections.Mapping`. It was
deprecated in python 3.8.

I have added the import as `from collections.abc import Mapping`, and
then using directly `Mapping` in line 44 (now 46) of client.py
`class Servers(Mapping)`.